### PR TITLE
fix: CSP unsafe-eval

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export default class IPut extends React.Component {
     className: '',
     defaultValue: '...',
     isError: () => false,
-    onChange: new Function()
+    onChange: () => {}
   }
   /**
    * set prop type


### PR DESCRIPTION
To be able to use ```new Function()``` in code, you need 'unsafe-eval' in CSP headers, which reduce security